### PR TITLE
feat: add streaming log reader

### DIFF
--- a/src/LogAnomalyEngine.Core/Reading/LogLineHandler.cs
+++ b/src/LogAnomalyEngine.Core/Reading/LogLineHandler.cs
@@ -1,0 +1,3 @@
+﻿namespace LogAnomalyEngine.Core.Reading;
+
+public delegate void LogLineHandler(ReadOnlySpan<byte> line);

--- a/src/LogAnomalyEngine.Core/Reading/StreamingLogReader.cs
+++ b/src/LogAnomalyEngine.Core/Reading/StreamingLogReader.cs
@@ -1,0 +1,127 @@
+﻿using System.Buffers;
+using LogAnomalyEngine.Core.Parsing;
+
+namespace LogAnomalyEngine.Core.Reading;
+
+public static class StreamingLogReader
+{
+    public const int DefaultBufferSize = 64 * 1024;
+
+    private const byte CarriageReturn = (byte)'\r';
+
+    public static long ReadLines(
+        Stream stream,
+        LogLineHandler handler,
+        int bufferSize = DefaultBufferSize)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        if (!stream.CanRead)
+        {
+            throw new ArgumentException(
+                "The supplied stream must be readable.",
+                nameof(stream));
+        }
+
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferSize);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+        var capacity = bufferSize;
+        var bufferedCount = 0;
+        long lineCount = 0;
+
+        try
+        {
+            while (true)
+            {
+                if (bufferedCount == capacity)
+                {
+                    GrowBuffer(ref buffer, ref capacity, bufferedCount);
+                }
+
+                var bytesRead = stream.Read(
+                    buffer.AsSpan(
+                        bufferedCount,
+                        capacity - bufferedCount));
+
+                if (bytesRead == 0)
+                {
+                    if (bufferedCount > 0)
+                    {
+                        handler(TrimCarriageReturn(
+                            buffer.AsSpan(0, bufferedCount)));
+
+                        lineCount++;
+                    }
+
+                    return lineCount;
+                }
+
+                var availableCount = bufferedCount + bytesRead;
+                var lineStart = 0;
+
+                while (true)
+                {
+                    var lineFeedIndex = ScalarLineScanner.FindNextLineFeed(
+                        buffer.AsSpan(0, availableCount),
+                        lineStart);
+
+                    if (lineFeedIndex < 0)
+                    {
+                        break;
+                    }
+
+                    var line = buffer.AsSpan(
+                        lineStart,
+                        lineFeedIndex - lineStart);
+
+                    handler(TrimCarriageReturn(line));
+                    lineCount++;
+
+                    lineStart = lineFeedIndex + 1;
+                }
+
+                bufferedCount = availableCount - lineStart;
+
+                if (bufferedCount > 0 && lineStart > 0)
+                {
+                    buffer.AsSpan(lineStart, bufferedCount)
+                        .CopyTo(buffer);
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static void GrowBuffer(
+        ref byte[] buffer,
+        ref int capacity,
+        int bufferedCount)
+    {
+        var newCapacity = checked(capacity * 2);
+        var newBuffer = ArrayPool<byte>.Shared.Rent(newCapacity);
+
+        buffer.AsSpan(0, bufferedCount)
+            .CopyTo(newBuffer);
+
+        ArrayPool<byte>.Shared.Return(buffer);
+
+        buffer = newBuffer;
+        capacity = newCapacity;
+    }
+
+    private static ReadOnlySpan<byte> TrimCarriageReturn(
+        ReadOnlySpan<byte> line)
+    {
+        if (!line.IsEmpty && line[^1] == CarriageReturn)
+        {
+            return line[..^1];
+        }
+
+        return line;
+    }
+}

--- a/tests/LogAnomalyEngine.Tests/Reading/StreamingLogReaderTests.cs
+++ b/tests/LogAnomalyEngine.Tests/Reading/StreamingLogReaderTests.cs
@@ -1,0 +1,210 @@
+﻿using System.Text;
+using LogAnomalyEngine.Core.Reading;
+
+namespace LogAnomalyEngine.Tests.Reading;
+
+public sealed class StreamingLogReaderTests
+{
+    [Fact]
+    public void ReadLines_EmptyStream_ProducesNoLines()
+    {
+        using var stream = CreateStream(string.Empty);
+        var lines = new List<string>();
+
+        var count = StreamingLogReader.ReadLines(
+            stream,
+            line => lines.Add(Encoding.UTF8.GetString(line)));
+
+        Assert.Equal(0, count);
+        Assert.Empty(lines);
+    }
+
+    [Fact]
+    public void ReadLines_SingleTerminatedLine_ReturnsLine()
+    {
+        using var stream = CreateStream("INFO started\n");
+        var lines = ReadAllLines(stream);
+
+        Assert.Equal(["INFO started"], lines);
+    }
+
+    [Fact]
+    public void ReadLines_SingleUnterminatedLine_ReturnsLine()
+    {
+        using var stream = CreateStream("INFO started");
+        var lines = ReadAllLines(stream);
+
+        Assert.Equal(["INFO started"], lines);
+    }
+
+    [Fact]
+    public void ReadLines_MultipleLines_ReturnsAllLines()
+    {
+        using var stream = CreateStream(
+            "INFO started\nWARN retry\nERROR failed\n");
+
+        var lines = ReadAllLines(stream);
+
+        Assert.Equal(
+            [
+                "INFO started",
+                "WARN retry",
+                "ERROR failed"
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_EmptyLines_PreservesEmptyLines()
+    {
+        using var stream = CreateStream("INFO\n\nERROR\n");
+        var lines = ReadAllLines(stream);
+
+        Assert.Equal(
+            [
+                "INFO",
+                string.Empty,
+                "ERROR"
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_CrlfLineEndings_RemovesCarriageReturn()
+    {
+        using var stream = CreateStream(
+            "INFO started\r\nWARN retry\r\n");
+
+        var lines = ReadAllLines(stream);
+
+        Assert.Equal(
+            [
+                "INFO started",
+                "WARN retry"
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_LineSplitAcrossChunks_ReconstructsLine()
+    {
+        using var stream = CreateStream(
+            "INFO first\nWARN second\nERROR third");
+
+        var lines = ReadAllLines(
+            stream,
+            bufferSize: 8);
+
+        Assert.Equal(
+            [
+                "INFO first",
+                "WARN second",
+                "ERROR third"
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_LineLargerThanInitialBuffer_GrowsBuffer()
+    {
+        var longMessage = new string('A', 128);
+
+        using var stream = CreateStream(
+            $"{longMessage}\nINFO next");
+
+        var lines = ReadAllLines(
+            stream,
+            bufferSize: 8);
+
+        Assert.Equal(
+            [
+                longMessage,
+                "INFO next"
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_MultibyteUtf8AcrossChunks_ReconstructsContent()
+    {
+        using var stream = CreateStream(
+            "INFO Користувач увійшов\nERROR Помилка");
+
+        var lines = ReadAllLines(
+            stream,
+            bufferSize: 7);
+
+        Assert.Equal(
+            [
+                "INFO Користувач увійшов",
+                "ERROR Помилка"
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_ReturnsProcessedLineCount()
+    {
+        using var stream = CreateStream(
+            "INFO first\nWARN second\nERROR third");
+
+        var lines = new List<string>();
+
+        var count = StreamingLogReader.ReadLines(
+            stream,
+            line => lines.Add(Encoding.UTF8.GetString(line)),
+            bufferSize: 8);
+
+        Assert.Equal(3, count);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ReadLines_NonPositiveBufferSize_ThrowsArgumentOutOfRangeException(
+        int bufferSize)
+    {
+        using var stream = CreateStream("INFO");
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => StreamingLogReader.ReadLines(
+                stream,
+                _ => { },
+                bufferSize));
+    }
+
+    [Fact]
+    public void ReadLines_HandlerThrows_PropagatesException()
+    {
+        using var stream = CreateStream("INFO first\nWARN second\n");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => StreamingLogReader.ReadLines(
+                stream,
+                _ => throw new InvalidOperationException("Test failure")));
+
+        Assert.Equal("Test failure", exception.Message);
+    }
+
+    private static List<string> ReadAllLines(
+        Stream stream,
+        int bufferSize = StreamingLogReader.DefaultBufferSize)
+    {
+        var lines = new List<string>();
+
+        StreamingLogReader.ReadLines(
+            stream,
+            line => lines.Add(Encoding.UTF8.GetString(line)),
+            bufferSize);
+
+        return lines;
+    }
+
+
+    private static MemoryStream CreateStream(string content)
+    {
+        return new MemoryStream(
+            Encoding.UTF8.GetBytes(content),
+            writable: false);
+    }
+}


### PR DESCRIPTION
## Summary

- adds a pooled streaming log reader
- processes UTF-8 input without per-line string decoding
- handles lines split across read boundaries
- supports lines larger than the initial buffer
- handles LF and CRLF line endings
- preserves empty lines and final unterminated lines
- adds reader correctness and boundary tests

Closes #4 