### PR TITLE
bench: add file-backed reader benchmark

### DIFF
--- a/benchmarks/LogAnomalyEngine.Benchmarks/Infrastructure/LogDatasetGenerator.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Infrastructure/LogDatasetGenerator.cs
@@ -1,0 +1,34 @@
+﻿using System.Text;
+
+namespace LogAnomalyEngine.Benchmarks.Infrastructure;
+
+internal static class LogDatasetGenerator
+{
+    private const string LogLine =
+        "2026-09-04T10:15:30.123Z INFO OrderService Request completed successfully id=123456 duration=42ms\n";
+
+    private static readonly byte[] LogLineBytes = Encoding.UTF8.GetBytes(LogLine);
+
+    public static byte[] Create(int targetSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(targetSize);
+
+        var lineCount = targetSize / LogLineBytes.Length;
+
+        if (lineCount == 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(targetSize),
+                "Target size must be large enough to contain at least one log line.");
+        }
+
+        var data = new byte[lineCount * LogLineBytes.Length];
+
+        for (var offset = 0; offset < data.Length; offset += LogLineBytes.Length)
+        {
+            LogLineBytes.CopyTo(data, offset);
+        }
+
+        return data;
+    }
+}

--- a/benchmarks/LogAnomalyEngine.Benchmarks/Program.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Running;
-using LogAnomalyEngine.Benchmarks.Reading;
 
-BenchmarkRunner.Run<StreamingLogReaderBenchmarks>();
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/benchmarks/LogAnomalyEngine.Benchmarks/Reading/FileStreamingLogReaderBenchmarks.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Reading/FileStreamingLogReaderBenchmarks.cs
@@ -1,0 +1,63 @@
+﻿using BenchmarkDotNet.Attributes;
+using LogAnomalyEngine.Benchmarks.Infrastructure;
+using LogAnomalyEngine.Core.Reading;
+
+namespace LogAnomalyEngine.Benchmarks.Reading;
+
+[MemoryDiagnoser]
+public class FileStreamingLogReaderBenchmarks : IDisposable
+{
+    private const int DatasetSize = 64 * 1024 * 1024;
+
+    private static readonly LogLineHandler LineHandler = static _ => { };
+
+    private string _filePath = null!;
+
+    [Params(4 * 1024, 64 * 1024, 1024 * 1024)]
+    public int BufferSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var data = LogDatasetGenerator.Create(DatasetSize);
+
+        _filePath = Path.Combine(
+            Path.GetTempPath(),
+            $"log-anomaly-engine-{Guid.NewGuid():N}.log");
+
+        File.WriteAllBytes(_filePath, data);
+    }
+
+    [Benchmark]
+    public long ReadLines()
+    {
+        using var stream = new FileStream(
+            _filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 1,
+            FileOptions.SequentialScan);
+
+        return StreamingLogReader.ReadLines(
+            stream,
+            LineHandler,
+            BufferSize);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        Dispose();
+    }
+
+    public void Dispose()
+    {
+        if (!string.IsNullOrEmpty(_filePath))
+        {
+            File.Delete(_filePath);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/benchmarks/LogAnomalyEngine.Benchmarks/Reading/StreamingLogReaderBenchmarks.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Reading/StreamingLogReaderBenchmarks.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text;
-using System.Buffers;
 using BenchmarkDotNet.Attributes;
 using LogAnomalyEngine.Core.Reading;
+using LogAnomalyEngine.Benchmarks.Infrastructure;
 
 namespace LogAnomalyEngine.Benchmarks.Reading;
 
@@ -20,7 +20,7 @@ public class StreamingLogReaderBenchmarks : IDisposable
     [GlobalSetup]
     public void Setup()
     {
-        var data = CreateDataset(DatasetSize);
+        var data = LogDatasetGenerator.Create(DatasetSize);
         _stream = new MemoryStream(data, writable: false);
     }
 
@@ -45,22 +45,5 @@ public class StreamingLogReaderBenchmarks : IDisposable
     {
         _stream?.Dispose();
         GC.SuppressFinalize(this);
-    }
-
-    private static byte[] CreateDataset(int targetSize)
-    {
-        const string line =
-            "2026-09-04T10:15:30.123Z INFO OrderService Request completed successfully id=123456 duration=42ms\n";
-
-        var lineBytes = Encoding.UTF8.GetBytes(line);
-        var lineCount = targetSize / lineBytes.Length;
-        var data = new byte[lineCount * lineBytes.Length];
-
-        for (var offset = 0; offset < data.Length; offset += lineBytes.Length)
-        {
-            lineBytes.CopyTo(data, offset);
-        }
-
-        return data;
     }
 }


### PR DESCRIPTION
## Summary

- adds a FileStream-backed BenchmarkDotNet benchmark
- measures 4 KiB, 64 KiB, and 1 MiB reader buffers
- uses a generated 64 MiB UTF-8 log dataset
- disables FileStream buffering to isolate the reader buffer configuration
- uses sequential file access
- avoids per-line work in the callback
- cleans up temporary benchmark files

Closes #8 