### PR TITLE
fix: harden streaming reader edge cases

### DIFF
--- a/src/LogAnomalyEngine.Core/Reading/StreamingLogReader.cs
+++ b/src/LogAnomalyEngine.Core/Reading/StreamingLogReader.cs
@@ -49,9 +49,7 @@ public static class StreamingLogReader
                 {
                     if (bufferedCount > 0)
                     {
-                        handler(TrimCarriageReturn(
-                            buffer.AsSpan(0, bufferedCount)));
-
+                        handler(buffer.AsSpan(0, bufferedCount));
                         lineCount++;
                     }
 

--- a/tests/LogAnomalyEngine.Tests/Reading/StreamingLogReaderTests.cs
+++ b/tests/LogAnomalyEngine.Tests/Reading/StreamingLogReaderTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using LogAnomalyEngine.Core.Reading;
+using LogAnomalyEngine.Tests.TestInfrastructure;
 
 namespace LogAnomalyEngine.Tests.Reading;
 
@@ -184,6 +185,118 @@ public sealed class StreamingLogReaderTests
                 _ => throw new InvalidOperationException("Test failure")));
 
         Assert.Equal("Test failure", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void ReadLines_StreamReturnsPartialReads_ReconstructsAllLines(
+        int maxBytesPerRead)
+    {
+        var data = Encoding.UTF8.GetBytes(
+            "INFO first\nWARN second\nERROR third");
+
+        using var stream = new ChunkedReadStream(
+            data,
+            maxBytesPerRead);
+
+        var lines = ReadAllLines(
+            stream,
+            bufferSize: 16);
+
+        Assert.Equal(
+            [
+                "INFO first",
+                "WARN second",
+                "ERROR third"
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_CrlfSplitAcrossReads_NormalizesLineEnding()
+    {
+        var data = Encoding.UTF8.GetBytes(
+            "INFO first\r\nWARN second\r\n");
+
+        using var stream = new ChunkedReadStream(
+            data,
+            maxBytesPerRead: 11);
+
+        var lines = ReadAllLines(
+            stream,
+            bufferSize: 16);
+
+        Assert.Equal(
+            [
+                "INFO first",
+                "WARN second"
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_UnterminatedLineEndingWithCarriageReturn_PreservesCarriageReturn()
+    {
+        using var stream = CreateStream("INFO started\r");
+
+        var lines = ReadAllLines(stream);
+
+        Assert.Equal(
+            ["INFO started\r"],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_InputContainsOnlyLineFeeds_PreservesEmptyLines()
+    {
+        using var stream = CreateStream("\n\n\n");
+
+        var lines = ReadAllLines(stream);
+
+        Assert.Equal(
+            [
+                string.Empty,
+                string.Empty,
+                string.Empty
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_LineRequiresMultipleBufferGrowths_ReconstructsLine()
+    {
+        var longLine = new string('A', 1024);
+
+        using var stream = CreateStream(
+            $"{longLine}\nINFO next");
+
+        var lines = ReadAllLines(
+            stream,
+            bufferSize: 8);
+
+        Assert.Equal(
+            [
+                longLine,
+                "INFO next"
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ReadLines_StreamReadThrows_PropagatesException()
+    {
+        using var stream = new ThrowingReadStream();
+
+        var exception = Assert.Throws<IOException>(
+            () => StreamingLogReader.ReadLines(
+                stream,
+                _ => { }));
+
+        Assert.Equal(
+            "Simulated read failure.",
+            exception.Message);
     }
 
     private static List<string> ReadAllLines(

--- a/tests/LogAnomalyEngine.Tests/TestInfrastructure/ChunkedReadStream.cs
+++ b/tests/LogAnomalyEngine.Tests/TestInfrastructure/ChunkedReadStream.cs
@@ -1,0 +1,73 @@
+﻿namespace LogAnomalyEngine.Tests.TestInfrastructure;
+
+internal sealed class ChunkedReadStream : Stream
+{
+    private readonly MemoryStream _innerStream;
+    private readonly int _maxBytesPerRead;
+
+    public ChunkedReadStream(byte[] data, int maxBytesPerRead)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxBytesPerRead);
+
+        _innerStream = new MemoryStream(data, writable: false);
+        _maxBytesPerRead = maxBytesPerRead;
+    }
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => _innerStream.Length;
+
+    public override long Position
+    {
+        get => _innerStream.Position;
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        return _innerStream.Read(
+            buffer,
+            offset,
+            Math.Min(count, _maxBytesPerRead));
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        return _innerStream.Read(
+            buffer[..Math.Min(buffer.Length, _maxBytesPerRead)]);
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _innerStream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/tests/LogAnomalyEngine.Tests/TestInfrastructure/ThrowingReadStream.cs
+++ b/tests/LogAnomalyEngine.Tests/TestInfrastructure/ThrowingReadStream.cs
@@ -1,0 +1,47 @@
+﻿namespace LogAnomalyEngine.Tests.TestInfrastructure;
+
+internal sealed class ThrowingReadStream : Stream
+{
+    public override bool CanRead => true;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        throw new IOException("Simulated read failure.");
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        throw new IOException("Simulated read failure.");
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary

- handles partial stream reads correctly
- covers one-byte and small chunk reads
- preserves CR in unterminated final lines
- normalizes CRLF only when LF is present
- adds coverage for CRLF split across reads
- adds multiple buffer growth scenarios
- verifies stream read failures are propagated

Closes #10 