### PR TITLE
bench: add line-length sensitivity benchmark

### DIFF
--- a/benchmarks/LogAnomalyEngine.Benchmarks/Infrastructure/LogDatasetGenerator.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Infrastructure/LogDatasetGenerator.cs
@@ -31,4 +31,39 @@ internal static class LogDatasetGenerator
 
         return data;
     }
+
+    public static byte[] CreateFixedWidth(
+        int targetSize,
+        int lineLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(targetSize);
+
+        if (lineLength < 2)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(lineLength),
+                "Line length must be at least two bytes.");
+        }
+
+        var lineCount = targetSize / lineLength;
+
+        if (lineCount == 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(targetSize),
+                "Target size must be large enough to contain at least one line.");
+        }
+
+        var data = new byte[lineCount * lineLength];
+
+        for (var offset = 0; offset < data.Length; offset += lineLength)
+        {
+            data.AsSpan(offset, lineLength - 1)
+                .Fill((byte)'A');
+
+            data[offset + lineLength - 1] = (byte)'\n';
+        }
+
+        return data;
+    }
 }

--- a/benchmarks/LogAnomalyEngine.Benchmarks/Reading/LineLengthImpactBenchmarks.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Reading/LineLengthImpactBenchmarks.cs
@@ -1,0 +1,58 @@
+﻿using BenchmarkDotNet.Attributes;
+using LogAnomalyEngine.Benchmarks.Infrastructure;
+using LogAnomalyEngine.Core.Reading;
+
+namespace LogAnomalyEngine.Benchmarks.Reading;
+
+[MemoryDiagnoser]
+public class LineLengthImpactBenchmarks : IDisposable
+{
+    private const int DatasetSize = 16_000_000;
+    private const int BufferSize = 64 * 1024;
+
+    private static readonly LogLineHandler LineHandler = static _ => { };
+
+    private MemoryStream _stream = null!;
+
+    [Params(
+        125,
+        1000,
+        16_000,
+        100_000)]
+    public int LineLength { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var data = LogDatasetGenerator.CreateFixedWidth(
+            DatasetSize,
+            LineLength);
+
+        _stream = new MemoryStream(
+            data,
+            writable: false);
+    }
+
+    [Benchmark]
+    public long ReadLines()
+    {
+        _stream.Position = 0;
+
+        return StreamingLogReader.ReadLines(
+            _stream,
+            LineHandler,
+            BufferSize);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        Dispose();
+    }
+
+    public void Dispose()
+    {
+        _stream?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## Summary

- adds a BenchmarkDotNet experiment for log-line length sensitivity
- keeps total processed data size fixed
- uses misaligned line lengths to exercise buffer compaction
- covers short, medium, large, and oversized log entries
- measures throughput and managed allocations

Closes #12 