### PR TITLE
bench: measure oversized line carryover cost

### DIFF
--- a/benchmarks/LogAnomalyEngine.Benchmarks/Infrastructure/LineBoundaryReadStream.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Infrastructure/LineBoundaryReadStream.cs
@@ -1,0 +1,101 @@
+﻿namespace LogAnomalyEngine.Benchmarks.Infrastructure;
+
+internal sealed class LineBoundaryReadStream : Stream
+{
+    private readonly MemoryStream _innerStream;
+    private readonly int _lineLength;
+    private readonly bool _alignReadsToLineBoundaries;
+
+    public LineBoundaryReadStream(
+        byte[] data,
+        int lineLength,
+        bool alignReadsToLineBoundaries)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(lineLength);
+
+        _innerStream = new MemoryStream(data, writable: false);
+        _lineLength = lineLength;
+        _alignReadsToLineBoundaries = alignReadsToLineBoundaries;
+    }
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => _innerStream.Length;
+
+    public override long Position
+    {
+        get => _innerStream.Position;
+        set => throw new NotSupportedException();
+    }
+
+    public void Reset()
+    {
+        _innerStream.Position = 0;
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var readCount = GetReadCount(count);
+
+        return _innerStream.Read(
+            buffer,
+            offset,
+            readCount);
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        var readCount = GetReadCount(buffer.Length);
+
+        return _innerStream.Read(buffer[..readCount]);
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _innerStream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private int GetReadCount(int requestedCount)
+    {
+        var positionInLine = (int)(_innerStream.Position % _lineLength);
+        var bytesUntilLineBoundary = _lineLength - positionInLine;
+
+        if (_alignReadsToLineBoundaries)
+        {
+            return Math.Min(
+                requestedCount,
+                bytesUntilLineBoundary);
+        }
+
+        return requestedCount;
+    }
+}

--- a/benchmarks/LogAnomalyEngine.Benchmarks/Reading/OversizedLineCarryoverBenchmarks.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Reading/OversizedLineCarryoverBenchmarks.cs
@@ -1,0 +1,72 @@
+﻿using BenchmarkDotNet.Attributes;
+using LogAnomalyEngine.Benchmarks.Infrastructure;
+using LogAnomalyEngine.Core.Reading;
+
+namespace LogAnomalyEngine.Benchmarks.Reading;
+
+[MemoryDiagnoser]
+public class OversizedLineCarryoverBenchmarks : IDisposable
+{
+    private const int DatasetSize = 64_000_000;
+    private const int LineLength = 100_000;
+    private const int BufferSize = 64 * 1024;
+
+    private static readonly LogLineHandler LineHandler = static _ => { };
+
+    private LineBoundaryReadStream _unalignedStream = null!;
+    private LineBoundaryReadStream _lineAlignedStream = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var data = LogDatasetGenerator.CreateFixedWidth(
+            DatasetSize,
+            LineLength);
+
+        _unalignedStream = new LineBoundaryReadStream(
+            data,
+            LineLength,
+            alignReadsToLineBoundaries: false);
+
+        _lineAlignedStream = new LineBoundaryReadStream(
+            data,
+            LineLength,
+            alignReadsToLineBoundaries: true);
+    }
+
+    [Benchmark(Baseline = true)]
+    public long UnalignedReads()
+    {
+        _unalignedStream.Reset();
+
+        return StreamingLogReader.ReadLines(
+            _unalignedStream,
+            LineHandler,
+            BufferSize);
+    }
+
+    [Benchmark]
+    public long LineAlignedReads()
+    {
+        _lineAlignedStream.Reset();
+
+        return StreamingLogReader.ReadLines(
+            _lineAlignedStream,
+            LineHandler,
+            BufferSize);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        Dispose();
+    }
+
+    public void Dispose()
+    {
+        _unalignedStream?.Dispose();
+        _lineAlignedStream?.Dispose();
+
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## Summary

- adds a controlled benchmark for oversized partial-line carryover
- compares aligned and unaligned stream read boundaries
- keeps the dataset, line length, and reader buffer size identical
- demonstrates measurable overhead from carrying partial oversized lines
- establishes a baseline for the next reader optimization

Closes #14 