### PR TITLE
feat: add Vector128 line scanner

### DIFF
--- a/benchmarks/LogAnomalyEngine.Benchmarks/Parsing/LineFeedScannerBenchmarks.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Parsing/LineFeedScannerBenchmarks.cs
@@ -1,0 +1,53 @@
+using BenchmarkDotNet.Attributes;
+using LogAnomalyEngine.Core.Parsing;
+
+namespace LogAnomalyEngine.Benchmarks.Parsing;
+
+[MemoryDiagnoser]
+public class LineFeedScannerBenchmarks
+{
+    private byte[] _buffer = null!;
+
+    [Params(
+        32,
+        128,
+        1024,
+        16 * 1024,
+        64 * 1024)]
+    public int BufferLength { get; set; }
+
+    [Params(false, true)]
+    public bool HasLineFeed { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _buffer = new byte[BufferLength];
+        Array.Fill(_buffer, (byte)'A');
+
+        if (HasLineFeed)
+        {
+            // Ставимо delimiter наприкінці, щоб усі реалізації
+            // проходили майже весь buffer і виконували порівнювану роботу.
+            _buffer[^1] = (byte)'\n';
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public int Scalar()
+    {
+        return ScalarLineScanner.FindNextLineFeed(_buffer);
+    }
+
+    [Benchmark]
+    public int Vector128()
+    {
+        return Vector128LineScanner.FindNextLineFeed(_buffer);
+    }
+
+    [Benchmark]
+    public int RuntimeIndexOf()
+    {
+        return _buffer.AsSpan().IndexOf((byte)'\n');
+    }
+}

--- a/benchmarks/LogAnomalyEngine.Benchmarks/Reading/LineFeedScannerBenchmarks.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Reading/LineFeedScannerBenchmarks.cs
@@ -1,6 +1,0 @@
-namespace LogAnomalyEngine.Benchmarks.Reading;
-
-public class LineFeedScannerBenchmarks
-{
-    
-}

--- a/benchmarks/LogAnomalyEngine.Benchmarks/Reading/LineFeedScannerBenchmarks.cs
+++ b/benchmarks/LogAnomalyEngine.Benchmarks/Reading/LineFeedScannerBenchmarks.cs
@@ -1,0 +1,6 @@
+namespace LogAnomalyEngine.Benchmarks.Reading;
+
+public class LineFeedScannerBenchmarks
+{
+    
+}

--- a/docs/research/result/0003-scalar-vector128-runtime-indexof.md
+++ b/docs/research/result/0003-scalar-vector128-runtime-indexof.md
@@ -1,0 +1,185 @@
+# Research Result 0003 — Scalar vs Vector128 vs Runtime IndexOf
+
+## Status
+
+Validated SIMD scanner comparison.
+
+## Date
+
+2026-09-04
+
+## Context
+
+The scalar line-feed scanner established during M1 is intentionally implemented as an explicit byte-by-byte loop so that it can serve as a non-vectorized reference baseline.
+
+During M2, a `Vector128<byte>` implementation was introduced to evaluate explicit SIMD acceleration. A third implementation based on `ReadOnlySpan<byte>.IndexOf` was benchmarked as a production-oriented reference because the .NET runtime may use architecture-specific vectorized implementations internally.
+
+The objective was not to prove that handwritten SIMD is inherently faster, but to determine which implementation provides the best measured behavior on the target runtime and hardware.
+
+## Implementations
+
+### Scalar
+
+Explicit byte-by-byte search.
+
+```text
+byte -> compare -> next byte
+```
+
+This implementation is retained as the correctness oracle and non-vectorized baseline.
+
+### Vector128
+
+Explicit `Vector128<byte>` comparison with a 16-byte vector width.
+
+The implementation:
+
+- loads 16 bytes at a time;
+- compares them against LF (`0x0A`);
+- extracts a bit mask;
+- uses trailing-zero count to locate the first matching byte;
+- falls back to scalar processing for the remaining tail.
+
+### Runtime IndexOf
+
+Uses:
+
+```csharp
+span.IndexOf((byte)'\n')
+```
+
+This delegates implementation details to the .NET runtime and allows the runtime to select architecture-specific optimizations.
+
+## Environment
+
+```text
+Platform:           macOS ARM64
+CPU:                Apple M5
+.NET SDK:           10.0.302
+.NET Runtime:       10.0.10
+BenchmarkDotNet:    0.15.8
+```
+
+## Benchmark design
+
+Buffer lengths:
+
+```text
+32 B
+128 B
+1 KiB
+16 KiB
+64 KiB
+```
+
+Two cases were measured:
+
+- no LF exists in the buffer;
+- LF is placed at the final byte.
+
+Both cases require scanning essentially the complete buffer.
+
+No managed allocations were observed in the measured operations.
+
+## Results — no delimiter
+
+| Buffer | Scalar | Vector128 | Runtime IndexOf | Vector128 speedup vs scalar | Runtime speedup vs scalar |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 32 B | 7.104 ns | 0.444 ns | 0.486 ns | 16.0x | 14.6x |
+| 128 B | 33.926 ns | 3.004 ns | 1.813 ns | 11.3x | 18.7x |
+| 1 KiB | 240.568 ns | 32.192 ns | 17.465 ns | 7.47x | 13.78x |
+| 16 KiB | 3,662.127 ns | 532.085 ns | 248.760 ns | 6.88x | 14.72x |
+| 64 KiB | 14,613.155 ns | 2,133.945 ns | 952.919 ns | 6.85x | 15.34x |
+
+## Results — delimiter at final byte
+
+| Buffer | Scalar | Vector128 | Runtime IndexOf | Vector128 speedup vs scalar | Runtime speedup vs scalar |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 32 B | 7.219 ns | 0.412 ns | 0.466 ns | 17.5x | 15.5x |
+| 128 B | 33.038 ns | 3.406 ns | 2.016 ns | 9.70x | 16.39x |
+| 1 KiB | 237.952 ns | 32.698 ns | 19.163 ns | 7.28x | 12.42x |
+| 16 KiB | 3,655.616 ns | 540.880 ns | 250.738 ns | 6.76x | 14.58x |
+| 64 KiB | 14,640.842 ns | 2,139.949 ns | 956.499 ns | 6.84x | 15.31x |
+
+## Key observations
+
+### Explicit SIMD is substantially faster than the scalar reference
+
+For large buffers, `Vector128` is approximately 6.8x faster than the scalar implementation.
+
+This validates the original hypothesis that delimiter scanning is highly suitable for SIMD acceleration.
+
+### Runtime IndexOf outperforms handwritten Vector128 for practical buffer sizes
+
+Starting at 128 bytes, `RuntimeIndexOf` is consistently faster than the explicit `Vector128` implementation.
+
+At 64 KiB without a delimiter:
+
+```text
+Vector128:      2,133.945 ns
+RuntimeIndexOf:   952.919 ns
+```
+
+The runtime implementation is therefore approximately:
+
+```text
+2.24x faster than the handwritten Vector128 implementation
+```
+
+for that workload.
+
+### The 32-byte result should not drive production design
+
+At 32 bytes, explicit `Vector128` is slightly faster than `RuntimeIndexOf`.
+
+However, the absolute difference is only a few hundredths of a nanosecond in this benchmark. That difference is too small to justify a separate production dispatch path by itself.
+
+### Match and no-match behavior are consistent
+
+Placing LF at the final byte produces results close to the no-match case.
+
+This is expected because both scenarios require scanning nearly the complete buffer.
+
+### No managed allocations were observed
+
+All three scanner implementations operate without observed managed allocations in the measured benchmark scenarios.
+
+## Decision
+
+Do not replace the production scalar reader directly with the handwritten `Vector128LineScanner` yet.
+
+The explicit `Vector128` implementation should be retained as:
+
+- a research implementation;
+- a correctness comparison target;
+- an explicit SIMD baseline;
+- a useful cross-platform experiment for ARM64 and x64.
+
+For production integration, `ReadOnlySpan<byte>.IndexOf` is currently the strongest candidate because it:
+
+- substantially outperforms the scalar implementation;
+- outperforms the handwritten Vector128 implementation for practical buffer sizes;
+- keeps production code simpler;
+- allows the .NET runtime to choose architecture-specific SIMD optimizations.
+
+## Next experiment
+
+The next step is an end-to-end reader A/B/C comparison:
+
+```text
+StreamingLogReader + ScalarLineScanner
+StreamingLogReader + Vector128LineScanner
+StreamingLogReader + Runtime IndexOf
+```
+
+The purpose is to determine how much scanner-level speedup survives at the complete reader level.
+
+A microbenchmark improvement must not be assumed to translate proportionally to end-to-end throughput.
+
+## Limitations
+
+These measurements apply to the tested Apple M5 / ARM64 environment and runtime version.
+
+The experiment should later be repeated on the Windows x64 development system.
+
+Absolute results between Apple M5 and the Windows machine must not be interpreted as an ARM64-versus-x64 CPU comparison. The relevant cross-platform question is whether the relative ordering and speedup trends reproduce on both systems.

--- a/src/LogAnomalyEngine.Core/Parsing/Vector128LineScanner.cs
+++ b/src/LogAnomalyEngine.Core/Parsing/Vector128LineScanner.cs
@@ -1,0 +1,68 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+
+namespace LogAnomalyEngine.Core.Parsing;
+
+public static class Vector128LineScanner
+{
+    private const byte LineFeed = (byte)'\n';
+
+    public static int FindNextLineFeed(
+        ReadOnlySpan<byte> buffer,
+        int startIndex = 0)
+    {
+        if (startIndex < 0 || startIndex > buffer.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(startIndex));
+        }
+
+        if (!Vector128.IsHardwareAccelerated)
+        {
+            return ScalarLineScanner.FindNextLineFeed(
+                buffer,
+                startIndex);
+        }
+
+        var remainingLength = buffer.Length - startIndex;
+
+        if (remainingLength < Vector128<byte>.Count)
+        {
+            return ScalarLineScanner.FindNextLineFeed(
+                buffer,
+                startIndex);
+        }
+
+        var target = Vector128.Create(LineFeed);
+        ref var bufferReference = ref MemoryMarshal.GetReference(buffer);
+
+        var vectorEnd = buffer.Length - Vector128<byte>.Count;
+        var index = startIndex;
+
+        while (index <= vectorEnd)
+        {
+            var current = Vector128.LoadUnsafe(
+                ref bufferReference,
+                (nuint)index);
+
+            var matches = Vector128.Equals(
+                current,
+                target);
+
+            var mask = Vector128.ExtractMostSignificantBits(matches);
+
+            if (mask != 0)
+            {
+                var matchOffset = BitOperations.TrailingZeroCount(mask);
+
+                return index + matchOffset;
+            }
+
+            index += Vector128<byte>.Count;
+        }
+
+        return ScalarLineScanner.FindNextLineFeed(
+            buffer,
+            index);
+    }
+}

--- a/tests/LogAnomalyEngine.Tests/Parsing/Vector128LineScannerTests.cs
+++ b/tests/LogAnomalyEngine.Tests/Parsing/Vector128LineScannerTests.cs
@@ -1,0 +1,182 @@
+using LogAnomalyEngine.Core.Parsing;
+
+namespace LogAnomalyEngine.Tests.Parsing;
+
+public sealed class Vector128LineScannerTests
+{
+    [Fact]
+    public void FindNextLineFeed_EmptyBuffer_ReturnsMinusOne()
+    {
+        ReadOnlySpan<byte> buffer = [];
+
+        var result = Vector128LineScanner.FindNextLineFeed(buffer);
+
+        Assert.Equal(-1, result);
+    }
+
+    [Fact]
+    public void FindNextLineFeed_BufferWithoutLineFeed_ReturnsMinusOne()
+    {
+        var buffer =
+            "INFO application started without delimiter"u8;
+
+        var result = Vector128LineScanner.FindNextLineFeed(buffer);
+
+        Assert.Equal(-1, result);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(14)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(30)]
+    [InlineData(31)]
+    [InlineData(32)]
+    [InlineData(33)]
+    [InlineData(63)]
+    [InlineData(64)]
+    [InlineData(65)]
+    public void FindNextLineFeed_LineFeedAtPosition_ReturnsExpectedIndex(
+        int lineFeedIndex)
+    {
+        var buffer = new byte[96];
+
+        Array.Fill(buffer, (byte)'A');
+        buffer[lineFeedIndex] = (byte)'\n';
+
+        var result =
+            Vector128LineScanner.FindNextLineFeed(buffer);
+
+        Assert.Equal(lineFeedIndex, result);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(31)]
+    public void FindNextLineFeed_StartOffset_ReturnsNextLineFeed(
+        int startIndex)
+    {
+        var buffer = new byte[64];
+
+        Array.Fill(buffer, (byte)'A');
+
+        buffer[8] = (byte)'\n';
+        buffer[40] = (byte)'\n';
+
+        var expected =
+            ScalarLineScanner.FindNextLineFeed(
+                buffer,
+                startIndex);
+
+        var actual =
+            Vector128LineScanner.FindNextLineFeed(
+                buffer,
+                startIndex);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void FindNextLineFeed_MultipleMatches_ReturnsFirstMatch()
+    {
+        var buffer = new byte[64];
+
+        Array.Fill(buffer, (byte)'A');
+
+        buffer[19] = (byte)'\n';
+        buffer[20] = (byte)'\n';
+        buffer[50] = (byte)'\n';
+
+        var result =
+            Vector128LineScanner.FindNextLineFeed(buffer);
+
+        Assert.Equal(19, result);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(15)]
+    public void FindNextLineFeed_BufferSmallerThanVector_MatchesScalar(
+        int length)
+    {
+        var buffer = new byte[length];
+
+        Array.Fill(buffer, (byte)'A');
+
+        if (length > 1)
+        {
+            buffer[length - 1] = (byte)'\n';
+        }
+
+        var expected =
+            ScalarLineScanner.FindNextLineFeed(buffer);
+
+        var actual =
+            Vector128LineScanner.FindNextLineFeed(buffer);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(97)]
+    public void FindNextLineFeed_InvalidStartIndex_ThrowsArgumentOutOfRangeException(
+        int startIndex)
+    {
+        var buffer = new byte[96];
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Vector128LineScanner.FindNextLineFeed(
+                buffer,
+                startIndex));
+    }
+
+    [Theory]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(31)]
+    [InlineData(32)]
+    [InlineData(63)]
+    [InlineData(64)]
+    [InlineData(127)]
+    [InlineData(128)]
+    [InlineData(1024)]
+    public void FindNextLineFeed_VariousBuffers_MatchesScalar(
+        int length)
+    {
+        var buffer = new byte[length];
+
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = (byte)('A' + (i % 26));
+        }
+
+        if (length > 5)
+        {
+            buffer[length * 3 / 4] = (byte)'\n';
+        }
+
+        for (var startIndex = 0; startIndex <= buffer.Length; startIndex++)
+        {
+            var expected =
+                ScalarLineScanner.FindNextLineFeed(
+                    buffer,
+                    startIndex);
+
+            var actual =
+                Vector128LineScanner.FindNextLineFeed(
+                    buffer,
+                    startIndex);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- adds an explicit Vector128 LF scanner
- preserves the scalar scanner as the correctness baseline
- adds boundary and scalar-equivalence tests
- compares scalar, explicit Vector128, and runtime IndexOf implementations
- keeps the production streaming reader unchanged

## Benchmark result

On Apple M5 / ARM64 / .NET SDK 10.0.302:

- Vector128 is approximately 6.8x faster than the scalar implementation for 64 KiB scans
- Runtime `Span.IndexOf` is approximately 15.3x faster than scalar
- Runtime `Span.IndexOf` is approximately 2.2x faster than the handwritten Vector128 implementation for large buffers
- no managed allocations were observed

The handwritten SIMD implementation is retained as a research baseline. Runtime IndexOf is the current production candidate.

Closes #20 