### PR TITLE
feat: add normalized event fingerprint

### DIFF
--- a/src/LogAnomalyEngine.Core/Detection/EventFingerprint.cs
+++ b/src/LogAnomalyEngine.Core/Detection/EventFingerprint.cs
@@ -1,0 +1,87 @@
+using LogAnomalyEngine.Core.Events;
+
+namespace LogAnomalyEngine.Core.Detection;
+
+public static class EventFingerprint
+{
+    private const ulong OffsetBasis = 14695981039346656037UL;
+    private const ulong Prime = 1099511628211UL;
+
+    // 0xFE та 0xFF не є валідними байтами UTF-8, тому можемо
+    // безпечно використовувати їх як службові маркери fingerprint.
+    private const byte NumericRunMarker = 0xFE;
+    private const byte FieldSeparator = 0xFF;
+
+    public static ulong Compute(LogEventView logEvent)
+    {
+        var hash = OffsetBasis;
+
+        hash = AddByte(hash, (byte)logEvent.Level);
+        hash = AddByte(hash, FieldSeparator);
+
+        hash = AddBytes(hash, logEvent.Source);
+        hash = AddByte(hash, FieldSeparator);
+
+        hash = AddNormalizedMessage(
+            hash,
+            logEvent.Message);
+
+        return hash;
+    }
+
+    private static ulong AddNormalizedMessage(
+        ulong hash,
+        ReadOnlySpan<byte> message)
+    {
+        var insideNumericRun = false;
+
+        foreach (var value in message)
+        {
+            if (IsAsciiDigit(value))
+            {
+                // Незалежно від кількості цифр у значенні весь числовий
+                // фрагмент представлений одним стабільним маркером.
+                if (!insideNumericRun)
+                {
+                    hash = AddByte(
+                        hash,
+                        NumericRunMarker);
+
+                    insideNumericRun = true;
+                }
+
+                continue;
+            }
+
+            insideNumericRun = false;
+            hash = AddByte(hash, value);
+        }
+
+        return hash;
+    }
+
+    private static ulong AddBytes(
+        ulong hash,
+        ReadOnlySpan<byte> values)
+    {
+        foreach (var value in values)
+        {
+            hash = AddByte(hash, value);
+        }
+
+        return hash;
+    }
+
+    private static ulong AddByte(
+        ulong hash,
+        byte value)
+    {
+        return unchecked(
+            (hash ^ value) * Prime);
+    }
+
+    private static bool IsAsciiDigit(byte value)
+    {
+        return value is >= (byte)'0' and <= (byte)'9';
+    }
+}

--- a/tests/LogAnomalyEngine.Tests/Detection/EventFingerprintTests.cs
+++ b/tests/LogAnomalyEngine.Tests/Detection/EventFingerprintTests.cs
@@ -1,0 +1,215 @@
+using LogAnomalyEngine.Core.Detection;
+using LogAnomalyEngine.Core.Events;
+
+namespace LogAnomalyEngine.Tests.Detection;
+
+public sealed class EventFingerprintTests
+{
+    [Fact]
+    public void Compute_SameEvent_ReturnsSameFingerprint()
+    {
+        var first = ComputeFingerprint(
+            LogLevel.Information,
+            "PaymentService"u8,
+            "Payment completed"u8);
+
+        var second = ComputeFingerprint(
+            LogLevel.Information,
+            "PaymentService"u8,
+            "Payment completed"u8);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Compute_DifferentNumericValues_ReturnsSameFingerprint()
+    {
+        var first = ComputeFingerprint(
+            LogLevel.Information,
+            "AuthService"u8,
+            "User 123 logged in from node 7"u8);
+
+        var second = ComputeFingerprint(
+            LogLevel.Information,
+            "AuthService"u8,
+            "User 456789 logged in from node 12"u8);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Compute_DifferentMessageStructure_ReturnsDifferentFingerprint()
+    {
+        var first = ComputeFingerprint(
+            LogLevel.Information,
+            "AuthService"u8,
+            "User 123 logged in"u8);
+
+        var second = ComputeFingerprint(
+            LogLevel.Information,
+            "AuthService"u8,
+            "User 123 authentication failed"u8);
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void Compute_DifferentSources_ReturnDifferentFingerprints()
+    {
+        var first = ComputeFingerprint(
+            LogLevel.Error,
+            "WorkerA"u8,
+            "Queue 123 failed"u8);
+
+        var second = ComputeFingerprint(
+            LogLevel.Error,
+            "WorkerB"u8,
+            "Queue 123 failed"u8);
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void Compute_DifferentLevels_ReturnDifferentFingerprints()
+    {
+        var information = ComputeFingerprint(
+            LogLevel.Information,
+            "Worker"u8,
+            "Request 123 completed"u8);
+
+        var error = ComputeFingerprint(
+            LogLevel.Error,
+            "Worker"u8,
+            "Request 123 completed"u8);
+
+        Assert.NotEqual(information, error);
+    }
+
+    [Fact]
+    public void Compute_MultipleNumericRuns_NormalizesEachRun()
+    {
+        var first = ComputeFingerprint(
+            LogLevel.Warning,
+            "Gateway"u8,
+            "Request 123 failed after 45 attempts on node 7"u8);
+
+        var second = ComputeFingerprint(
+            LogLevel.Warning,
+            "Gateway"u8,
+            "Request 9 failed after 1000 attempts on node 42"u8);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Compute_NumberStructureStillAffectsFingerprint()
+    {
+        var singleRun = ComputeFingerprint(
+            LogLevel.Information,
+            "Worker"u8,
+            "Value 1234"u8);
+
+        var separateRuns = ComputeFingerprint(
+            LogLevel.Information,
+            "Worker"u8,
+            "Value 12 34"u8);
+
+        Assert.NotEqual(singleRun, separateRuns);
+    }
+
+    [Fact]
+    public void Compute_NumbersInsideWords_AreNormalized()
+    {
+        var first = ComputeFingerprint(
+            LogLevel.Information,
+            "Worker"u8,
+            "worker123 processed item456"u8);
+
+        var second = ComputeFingerprint(
+            LogLevel.Information,
+            "Worker"u8,
+            "worker999 processed item7"u8);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Compute_SourceNumbers_AreNotNormalized()
+    {
+        var first = ComputeFingerprint(
+            LogLevel.Information,
+            "Worker1"u8,
+            "Processed request 123"u8);
+
+        var second = ComputeFingerprint(
+            LogLevel.Information,
+            "Worker2"u8,
+            "Processed request 456"u8);
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void Compute_Utf8Message_NormalizesNumbersWithoutChangingTextStructure()
+    {
+        var first = ComputeFingerprint(
+            LogLevel.Error,
+            "PaymentService"u8,
+            "Помилка платежу 123 для користувача 456"u8);
+
+        var second = ComputeFingerprint(
+            LogLevel.Error,
+            "PaymentService"u8,
+            "Помилка платежу 999 для користувача 7"u8);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Compute_KnownInput_ReturnsStableFingerprint()
+    {
+        var fingerprint = ComputeFingerprint(
+            LogLevel.Error,
+            "PaymentService"u8,
+            "Payment 123 failed"u8);
+
+        Assert.Equal(
+            17024915595914404356UL,
+            fingerprint);
+    }
+
+    private static ulong ComputeFingerprint(
+        LogLevel level,
+        ReadOnlySpan<byte> source,
+        ReadOnlySpan<byte> message)
+    {
+        const int TimestampLength = 20;
+
+        var sourceOffset = TimestampLength;
+        var messageOffset = sourceOffset + source.Length;
+
+        var rawLine = new byte[
+            TimestampLength +
+            source.Length +
+            message.Length];
+
+        "2026-09-05T20:00:00Z"u8.CopyTo(rawLine);
+
+        source.CopyTo(
+            rawLine.AsSpan(sourceOffset));
+
+        message.CopyTo(
+            rawLine.AsSpan(messageOffset));
+
+        var logEvent = new LogEventView(
+            rawLine,
+            timestampRange: 0..TimestampLength,
+            level,
+            sourceRange:
+                sourceOffset..messageOffset,
+            messageRange:
+                messageOffset..rawLine.Length);
+
+        return EventFingerprint.Compute(logEvent);
+    }
+}


### PR DESCRIPTION
## Summary

- adds a deterministic 64-bit event fingerprint based on FNV-1a
- operates directly on LogEventView without string materialization
- includes log level and source in the fingerprint
- normalizes decimal numeric runs in message payloads
- preserves stable message structure
- supports UTF-8 input
- adds a deterministic regression value for cross-run reproducibility

## Behavior

Messages that differ only in numeric values produce the same fingerprint:

User 123 logged in from node 7
User 456789 logged in from node 12

Structurally different messages produce different fingerprints.

Source values and log levels remain part of the fingerprint and are not normalized.

## Validation

- Release build passes
- all unit tests pass
- Native AOT publish for osx-arm64 passes
- deterministic fingerprint contract is covered by a regression test

Closes #36 